### PR TITLE
Log calnet UID and callink OID, move logging to plugin

### DIFF
--- a/ircbot/plugin/create.py
+++ b/ircbot/plugin/create.py
@@ -1,7 +1,13 @@
 """Approve accounts."""
 import random
+import ssl
 
 from celery import exceptions
+from celery.events import EventReceiver
+from kombu import Connection
+
+from ircbot.ircbot import IRC_CHANNELS_ANNOUNCE
+from ircbot.ircbot import IRC_CHANNELS_OPER
 
 
 def register(bot):
@@ -50,3 +56,77 @@ def flip(bot, msg):
     msg.respond('my quantum randomness says: {}'.format(
         random.choice(('approve', 'reject')),
     ))
+
+
+def celery_listener(bot, celery, uri):
+    """Listen for events from Celery, relay to IRC."""
+    connection = Connection(uri, ssl={
+        'ssl_ca_certs': '/etc/ssl/certs/ca-certificates.crt',
+        'ssl_cert_reqs': ssl.CERT_REQUIRED,
+    })
+
+    def bot_announce(targets, message):
+        for target in targets:
+            bot.say(target, message)
+
+    def on_account_created(event):
+        request = event['request']
+
+        if request['calnet_uid']:
+            calnet_id = 'Calnet UID: {}'.format(request['calnet_uid'])
+        elif request['calnet_oid']:
+            calnet_id = 'Calnet OID: {}'.format(request['calnet_oid'])
+        else:
+            calnet_id = 'No Calnet UID or OID set'
+
+        bot_announce(
+            IRC_CHANNELS_ANNOUNCE,
+            '{user} created ({real_name}, {calnet_id})'.format(
+                user=request['user_name'],
+                real_name=request['real_name'],
+                calnet_id=calnet_id,
+            ),
+        )
+
+    def on_account_submitted(event):
+        request = event['request']
+        bot_announce(
+            IRC_CHANNELS_OPER,
+            '{user} ({real_name}) needs approval: {reasons}'.format(
+                user=request['user_name'],
+                real_name=request['real_name'],
+                reasons=', '.join(request['reasons']),
+            ),
+        )
+
+    def on_account_approved(event):
+        request = event['request']
+        bot_announce(
+            IRC_CHANNELS_ANNOUNCE,
+            '{user} was approved, now pending creation.'.format(
+                user=request['user_name'],
+            ),
+        )
+
+    def on_account_rejected(event):
+        request = event['request']
+        bot_announce(
+            IRC_CHANNELS_ANNOUNCE,
+            '{user} was rejected.'.format(
+                user=request['user_name'],
+            ),
+        )
+
+    while True:
+        with connection as conn:
+            recv = EventReceiver(
+                conn,
+                app=celery,
+                handlers={
+                    'ocflib.account_created': on_account_created,
+                    'ocflib.account_submitted': on_account_submitted,
+                    'ocflib.account_approved': on_account_approved,
+                    'ocflib.account_rejected': on_account_rejected,
+                },
+            )
+            recv.capture(limit=None, timeout=None)

--- a/ircbot/plugin/create.py
+++ b/ircbot/plugin/create.py
@@ -73,18 +73,18 @@ def celery_listener(bot, celery, uri):
         request = event['request']
 
         if request['calnet_uid']:
-            calnet_id = 'Calnet UID: {}'.format(request['calnet_uid'])
-        elif request['calnet_oid']:
-            calnet_id = 'Calnet OID: {}'.format(request['calnet_oid'])
+            uid_or_gid = 'Calnet UID: {}'.format(request['calnet_uid'])
+        elif request['callink_oid']:
+            uid_or_gid = 'Callink OID: {}'.format(request['callink_oid'])
         else:
-            calnet_id = 'No Calnet UID or OID set'
+            uid_or_gid = 'No Calnet UID or OID set'
 
         bot_announce(
             IRC_CHANNELS_ANNOUNCE,
-            '{user} created ({real_name}, {calnet_id})'.format(
+            '{user} created ({real_name}, {uid_or_gid})'.format(
                 user=request['user_name'],
                 real_name=request['real_name'],
-                calnet_id=calnet_id,
+                uid_or_gid=uid_or_gid,
             ),
         )
 


### PR DESCRIPTION
This is for [rt#6971](https://rt.ocf.berkeley.edu/Ticket/Display.html?id=6971). It logs lines like `jvperrin created (Jason Perrin, Calnet UID: 1101587)` in #atool. I also moved all the logging stuff to the `create` plugin, since there was a comment about doing that.