### PR TITLE
Allow fragments in github urls

### DIFF
--- a/ircbot/plugin/github.py
+++ b/ircbot/plugin/github.py
@@ -3,7 +3,7 @@ import github3
 
 
 def register(bot):
-    bot.listen(r'https?://github.com/([^/]+)/([^/]+?)/?(?: |$)', project_info)
+    bot.listen(r'https?://github.com/([^/]+)/([^/]+?)/?(?:[ #]|$)', project_info)
     bot.listen(r'https?://github.com/([^/]+)/([^/]+)/issues/([0-9]+)/?\b', issue_info)
     bot.listen(r'https?://github.com/([^/]+)/([^/]+)/pull/([0-9]+)/?\b', pr_info)
 


### PR DESCRIPTION
```
<asottile> https://github.com/pre-commit/pre-commit#foo
<create> pre-commit/pre-commit#foo | 1743 stars | A framework for managing and maintaining multi-language pre-commit hooks.
<create-asottile> pre-commit/pre-commit | 1743 stars | A framework for managing and maintaining multi-language pre-commit hooks.
```