### PR TITLE
what_is: make regex lazier

### DIFF
--- a/ircbot/plugin/what_is.py
+++ b/ircbot/plugin/what_is.py
@@ -4,7 +4,7 @@ from ircbot import db
 
 def register(bot):
     bot.listen(r'^(what|who) (?:is|are) (.+)$', what_is, require_mention=True)
-    bot.listen(r'^know that (.+) (?:is|are) (.+)$', know_that, require_mention=True)
+    bot.listen(r'^know that (.+?) (?:is|are) (.+)$', know_that, require_mention=True)
 
 
 def what_is(bot, msg):


### PR DESCRIPTION
This fixes a bug where you do something like:

    create: know that the pre-commit rule is those who don't use pre-commit are doomed

Most people would expect "the pre-commit rule" to be the key and "those
who don't use pre-commit are doomed", but prior to this change, it used
"the pre-commit rule is those who don't use pre-commit" as the key and
"doomed" as the value.