### PR TITLE
Revert "Make trailing delimiter on replacements optional"

### DIFF
--- a/ircbot/plugin/regex.py
+++ b/ircbot/plugin/regex.py
@@ -3,7 +3,7 @@ import re
 
 
 def register(bot):
-    bot.listen(r'(?:^| )s([!@"#$%&\'*./:;=?\\^_`|~])(.+)\1(.*)\1?g?$', replace)
+    bot.listen(r'(?:^| )s([!@"#$%&\'*./:;=?\\^_`|~])(.+)\1(.*)\1g?$', replace)
 
 
 def replace(bot, msg):


### PR DESCRIPTION
This reverts commit fc5e2da06f972ace7fb2ff2335aac06cd106314e.

@jvperrin @chriskuehl this seems to fix this for me.  I'm really not sure why though