### PR TITLE
Make "!quote rand" not case-sensitive

### DIFF
--- a/ircbot/plugin/quotes.py
+++ b/ircbot/plugin/quotes.py
@@ -23,7 +23,7 @@ def rand(bot, msg):
         c.execute(
             'SELECT * FROM quotes WHERE is_deleted = 0 ' +
             ' '.join(
-                'AND quote LIKE %s'
+                'AND quote LIKE %s COLLATE utf8mb4_unicode_ci'
                 for _ in arg
             ) +
             ' ORDER BY RAND() LIMIT 1',


### PR DESCRIPTION
Before:

```
<ckuehl> !quote rand bsd
<create> ckuehl: There are... no quotes?
```

After:

```
<ckuehl> !quote rand bsd
<create-ckuehl> Quote #60: <asottile> ckuehl: it just hit me, the irony of always shitting on BSD, but like berkeley <asottile> myabe I've had too many drinks
```