### PR TITLE
Hide rt ticket names for security queue

### DIFF
--- a/ircbot/plugin/request_tracker.py
+++ b/ircbot/plugin/request_tracker.py
@@ -18,6 +18,8 @@ def show_ticket(bot, msg):
     for ticket in REGEX.findall(msg.text):
         try:
             t = RtTicket.from_number(rt, int(ticket))
+            if t.queue == 'security':
+                t = t._replace(subject='(security ticket)')
             msg.respond(str(t))
         except AssertionError:
             pass


### PR DESCRIPTION
Security tickets can be sensitive, so we probably shouldn't broadcast some of their sensitive information (like the subject line) to the world.