### PR TITLE
update cryptography requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ cffi==1.11.5
 chardet==3.0.4
 ckuehl-upsidedown==0.4
 cracklib==2.9.3
-cryptography==2.2.2
+cryptography==2.3
 dnspython==1.15.0
 github3.py==1.1.0
 idna==2.6


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-10903

Version 2.3 is unaffected by the CVE.