### PR TITLE
Phabulous Macros @ OCF

### DIFF
--- a/ircbot/plugin/macros.py
+++ b/ircbot/plugin/macros.py
@@ -1,0 +1,64 @@
+"""Provide OCF image macros, inspired by Phabricator Macros"""
+from ircbot import db
+
+
+def register(bot):
+    bot.listen(r'^#m (\w+)$', show)
+    bot.listen(r'#m add (\w+) (.+)$', add)
+    bot.listen(r'#m delete (\w+)$', delete)
+
+
+def show(bot, msg):
+    """Return a macro by slug."""
+    slug = msg.match.group(1)
+
+    with db.cursor(password=bot.mysql_password) as c:
+        c.execute(
+            'SELECT link FROM macros WHERE slug = %s',
+            (slug,)
+        )
+        macro = c.fetchone()
+        if macro is not None:
+            msg.respond(macro['link'], ping=False)
+        else:
+            msg.respond('macro `{}` does not exist.'.format(slug))
+
+
+def add(bot, msg):
+    """Add a new macro."""
+
+    slug = msg.match.group(1)
+    link = msg.match.group(2)
+
+    if len(link) > 80:
+        msg.respond('please try to keep macro links below 80 characters')
+
+    with db.cursor(password=bot.mysql_password) as c:
+
+        c.execute('SELECT * FROM macros WHERE slug = %s', (slug,))
+        result = c.fetchone()
+        if result is not None:
+            msg.respond(
+                'macro `{}` already exists as {}'.format(
+                    result['slug'],
+                    result['link'],
+                )
+            )
+        else:
+            c.execute(
+                'INSERT INTO macros (slug, link) VALUES (%s, %s)',
+                (slug, link)
+            )
+            msg.respond('macro added as `{}`'.format(slug))
+
+
+def delete(bot, msg):
+    """Delete a macro."""
+
+    slug = msg.match.group(1)
+    with db.cursor(password=bot.mysql_password) as c:
+        c.execute(
+            'DELETE FROM macros WHERE slug = %s',
+            (slug,)
+        )
+        msg.respond('macro `{}` has been deleted.'.format(slug))

--- a/ircbot/plugin/macros.py
+++ b/ircbot/plugin/macros.py
@@ -31,7 +31,7 @@ def add(bot, msg):
     link = msg.match.group(2)
 
     if len(slug) > 50 or len(link) > 100:
-        msg.respond('macro slugs must be < 50 and links < 100 characters')
+        msg.respond('macro slugs must be <= 50 and links <= 100 characters')
         return
 
     if len(link) > 80:

--- a/ircbot/plugin/macros.py
+++ b/ircbot/plugin/macros.py
@@ -3,9 +3,9 @@ from ircbot import db
 
 
 def register(bot):
-    bot.listen(r'^#m (\w+)$', show)
-    bot.listen(r'#m add (\w+) (.+)$', add)
-    bot.listen(r'#m delete (\w+)$', delete)
+    bot.listen(r'#m (\w+)', show)
+    bot.listen(r'^#m add (\w+) (.+)$', add)
+    bot.listen(r'^#m delete (\w+)$', delete)
 
 
 def show(bot, msg):
@@ -29,6 +29,10 @@ def add(bot, msg):
 
     slug = msg.match.group(1)
     link = msg.match.group(2)
+
+    if len(slug) > 50 or len(link) > 100:
+        msg.respond('macro slugs must be < 50 and links < 100 characters')
+        return
 
     if len(link) > 80:
         msg.respond('please try to keep macro links below 80 characters')


### PR DESCRIPTION
this brings a simple adaptation of phabricator macros\[0\] to OCF. they are a staple at facebook

now you can do something like
![macroexample](https://user-images.githubusercontent.com/1916822/45015718-690ba380-afd7-11e8-8b70-9538bc09b309.png)

to add do `#m add <slug> <link>` and delete `#m delete <slug>`

\[0\]: https://secure.phabricator.com/project/profile/283/
