### PR TITLE
Add Discourse shortcut plugin

### DIFF
--- a/ircbot/ircbot.py
+++ b/ircbot/ircbot.py
@@ -100,6 +100,7 @@ class CreateBot(irc.bot.SingleServerIRCBot):
             marathon_creds,
             googlesearch_key,
             googlesearch_cx,
+            discourse_apikey,
     ):
         self.recent_messages = collections.defaultdict(
             functools.partial(collections.deque, maxlen=NUM_RECENT_MESSAGES),
@@ -114,6 +115,7 @@ class CreateBot(irc.bot.SingleServerIRCBot):
         self.marathon_creds = marathon_creds
         self.googlesearch_key = googlesearch_key
         self.googlesearch_cx = googlesearch_cx
+        self.discourse_apikey = discourse_apikey
         self.listeners = set()
         self.plugins = {}
         self.extra_channels = set()  # plugins can add stuff here
@@ -350,12 +352,13 @@ def main():
     )
     googlesearch_key = conf.get('googlesearch', 'key')
     googlesearch_cx = conf.get('googlesearch', 'cx')
+    discourse_apikey = conf.get('discourse', 'apikey')
 
     # irc bot thread
     bot = CreateBot(
         tasks, nickserv_password, rt_password, rackspace_apikey,
         weather_apikey, mysql_password, marathon_creds,
-        googlesearch_key, googlesearch_cx,
+        googlesearch_key, googlesearch_cx, discourse_apikey,
     )
     bot_thread = threading.Thread(target=bot.start, daemon=True)
     bot_thread.start()

--- a/ircbot/plugin/discourse.py
+++ b/ircbot/plugin/discourse.py
@@ -1,0 +1,21 @@
+"""Print Discourse topic information."""
+import re
+
+from ocflib.infra.discourse import DiscourseTopic
+
+
+REGEX = re.compile(r'(?:d#|ocf.io/d/)([0-9]+)')
+
+
+def register(bot):
+    bot.listen(REGEX.pattern, show_topic)
+
+
+def show_topic(bot, msg):
+    """Show Discourse topic details."""
+    for topic in REGEX.findall(msg.text):
+        try:
+            d = DiscourseTopic.from_number(bot.discourse_apikey, int(topic))
+            msg.respond(str(d))
+        except AssertionError:
+            pass

--- a/ircbot/plugin/discourse.py
+++ b/ircbot/plugin/discourse.py
@@ -1,6 +1,7 @@
 """Print Discourse topic information."""
 import re
 
+from ocflib.infra.discourse import DiscourseError
 from ocflib.infra.discourse import DiscourseTopic
 
 
@@ -17,5 +18,5 @@ def show_topic(bot, msg):
         try:
             d = DiscourseTopic.from_number(bot.discourse_apikey, int(topic))
             msg.respond(str(d))
-        except AssertionError:
+        except DiscourseError:
             pass


### PR DESCRIPTION
This works exactly like the RT shortcut plugin:

```
14:13 <@dkessler> d#129
14:13 <create-dkessler> dkessler: d#129: "Kubernetes" | Projects, started by dkessler | https://ocf.io/d/129
```