### PR TITLE
who is in the lab: prevent line breaks in middle of usernames

### DIFF
--- a/ircbot/plugin/lab.py
+++ b/ircbot/plugin/lab.py
@@ -20,8 +20,8 @@ def in_lab(bot, msg):
 
 
 def _prevent_ping(staffer):
-    """Hack to prevent pinging the person by inserting a zero-width space in their name."""
-    return staffer[0] + '\u200b' + staffer[1:]
+    """Hack to prevent pinging the person by inserting a zero-width no-break space in their name."""
+    return staffer[0] + '\u2060' + staffer[1:]
 
 
 def who_is_in_lab(bot, msg):


### PR DESCRIPTION
"who is in the lab" output currently inserts U+200B ZERO WIDTH SPACE
into usernames to prevent clients from alerting the mentioned users.
While this usually works as intended, section 23.2 of the Unicode
standard [1] indicates that U+200B "indicates a word break or line break
opportunity", permitting clients to wrap lines in the middle of
usernames.  To prevent this, Use U+2060 WORD JOINER, a zero-width
no-break space, instead.

[1] http://www.unicode.org/versions/Unicode11.0.0/ch23.pdf