### PR TITLE
add a plugin to show the contents of a linked tweet

### DIFF
--- a/ircbot/ircbot.py
+++ b/ircbot/ircbot.py
@@ -101,6 +101,7 @@ class CreateBot(irc.bot.SingleServerIRCBot):
             googlesearch_key,
             googlesearch_cx,
             discourse_apikey,
+            twitter_apikeys,
     ):
         self.recent_messages = collections.defaultdict(
             functools.partial(collections.deque, maxlen=NUM_RECENT_MESSAGES),
@@ -116,6 +117,7 @@ class CreateBot(irc.bot.SingleServerIRCBot):
         self.googlesearch_key = googlesearch_key
         self.googlesearch_cx = googlesearch_cx
         self.discourse_apikey = discourse_apikey
+        self.twitter_apikeys = twitter_apikeys
         self.listeners = set()
         self.plugins = {}
         self.extra_channels = set()  # plugins can add stuff here
@@ -353,12 +355,17 @@ def main():
     googlesearch_key = conf.get('googlesearch', 'key')
     googlesearch_cx = conf.get('googlesearch', 'cx')
     discourse_apikey = conf.get('discourse', 'apikey')
+    twitter_apikeys = (
+        conf.get('twitter', 'apikey'),
+        conf.get('twitter', 'apisecret'),
+    )
 
     # irc bot thread
     bot = CreateBot(
         tasks, nickserv_password, rt_password, rackspace_apikey,
         weather_apikey, mysql_password, marathon_creds,
         googlesearch_key, googlesearch_cx, discourse_apikey,
+        twitter_apikeys,
     )
     bot_thread = threading.Thread(target=bot.start, daemon=True)
     bot_thread.start()

--- a/ircbot/plugin/twitter.py
+++ b/ircbot/plugin/twitter.py
@@ -1,8 +1,9 @@
-"""Post the contents of linked tweets."""
-import requests
+"""Post the contents of tweets."""
 from functools import lru_cache
 
-API = 'https://api.twitter.com'
+import requests
+
+TWITTER_API = 'https://api.twitter.com'
 
 
 def register(bot):
@@ -12,7 +13,7 @@ def register(bot):
 @lru_cache(maxsize=1)
 def _get_token(apikeys):
     resp = requests.post(
-        '{}/oauth2/token'.format(API),
+        '{}/oauth2/token'.format(TWITTER_API),
         data={'grant_type': 'client_credentials'},
         auth=apikeys,
     )
@@ -27,7 +28,7 @@ def _get_tweet(apikeys, status_id, retry=True):
     bearer_token = _get_token(apikeys)
 
     resp = requests.get('{}/1.1/statuses/show.json?id={}&tweet_mode=extended'.format(
-        API,
+        TWITTER_API,
         status_id,
     ), headers={
         'Authorization': 'Bearer {}'.format(bearer_token),
@@ -62,7 +63,7 @@ def _format_tweet(tweet):
             _format_media(media, url),
         )
     contents = contents.replace('\n', ' ')
-    return '@{handle} ({realname}): {contents}'.format(
+    return '@\x02{handle}\x02 ({realname}): {contents}'.format(
         handle=tweet['user']['screen_name'],
         realname=tweet['user']['name'],
         contents=contents,
@@ -70,8 +71,7 @@ def _format_tweet(tweet):
 
 
 def show_tweet(bot, msg):
-    """Show tweet content."""
+    """Show the user and content of a linked tweet."""
     tweet = _get_tweet(bot.twitter_apikeys, msg.match.group(1))
     if tweet:
-        print(_format_tweet(tweet))
         msg.respond(_format_tweet(tweet), ping=False)

--- a/ircbot/plugin/twitter.py
+++ b/ircbot/plugin/twitter.py
@@ -6,7 +6,7 @@ bearer_token = None
 
 
 def register(bot):
-    bot.listen(r'https?://(mobile\.)?twitter\.com/[^/]+/status/([0-9]+)', show_tweet)
+    bot.listen(r'https?://(?:mobile\.|www\.|m\.)?twitter\.com/[^/]+/status/([0-9]+)', show_tweet)
 
 
 def _refresh_token(apikeys):
@@ -19,11 +19,11 @@ def _refresh_token(apikeys):
     resp.raise_for_status()
 
     authorization = resp.json()
-    assert(authorization['token_type'] == 'bearer')
+    assert authorization['token_type'] == 'bearer'
     bearer_token = authorization['access_token']
 
 
-def _tweet(apikeys, status_id):
+def _get_tweet(apikeys, status_id):
     if bearer_token is None:
         _refresh_token(apikeys)
 
@@ -33,19 +33,32 @@ def _tweet(apikeys, status_id):
     ), headers={
         'Authorization': 'Bearer {}'.format(bearer_token),
     })
+    if resp.status_code == 404:
+        return None
     resp.raise_for_status()
 
     return resp.json()
 
 
+def _format_media(media, url):
+    media_urls = [medium['media_url_https']
+                  for medium in media if medium['type'] == 'photo']
+    if any([medium['type'] != 'photo' for medium in media]):
+        media_urls += [url]
+    return ' '.join(media_urls)
+
+
 def _format_tweet(tweet):
     contents = tweet['full_text']
-    media = tweet['extended_entities']['media']
+    media = tweet.get('extended_entities', {}).get('media')
     if media:
+        # url is the same for all media
+        url = media[0]['url']
         contents = contents.replace(
-            media[0]['url'],
-            ' '.join([medium['media_url_https'] for medium in media]),
+            url,
+            _format_media(media, url),
         )
+    contents = contents.replace('\n', ' ')
     return '@{handle} ({realname}): {contents}'.format(
         handle=tweet['user']['screen_name'],
         realname=tweet['user']['name'],
@@ -55,5 +68,7 @@ def _format_tweet(tweet):
 
 def show_tweet(bot, msg):
     """Show tweet content."""
-    tweet = _tweet(bot.twitter_apikeys, msg.match.group(2))
-    msg.respond(_format_tweet(tweet), ping=False)
+    tweet = _get_tweet(bot.twitter_apikeys, msg.match.group(1))
+    if tweet:
+        print(_format_tweet(tweet))
+        msg.respond(_format_tweet(tweet), ping=False)

--- a/ircbot/plugin/twitter.py
+++ b/ircbot/plugin/twitter.py
@@ -33,7 +33,8 @@ def _get_tweet(apikeys, status_id, retry=True):
     ), headers={
         'Authorization': 'Bearer {}'.format(bearer_token),
     })
-    if resp.status_code == 404:
+    if resp.status_code == 404 or resp.status_code == 403:
+        # 403 indicates protected account, so just give up
         return None
     if resp.status_code == 401 and retry:
         _get_token.cache_clear()

--- a/ircbot/plugin/twitter.py
+++ b/ircbot/plugin/twitter.py
@@ -1,0 +1,59 @@
+"""Post the contents of linked tweets."""
+import requests
+
+API = 'https://api.twitter.com'
+bearer_token = None
+
+
+def register(bot):
+    bot.listen(r'https?://(mobile\.)?twitter\.com/[^/]+/status/([0-9]+)', show_tweet)
+
+
+def _refresh_token(apikeys):
+    global bearer_token
+    resp = requests.post(
+        '{}/oauth2/token'.format(API),
+        data={'grant_type': 'client_credentials'},
+        auth=apikeys,
+    )
+    resp.raise_for_status()
+
+    authorization = resp.json()
+    assert(authorization['token_type'] == 'bearer')
+    bearer_token = authorization['access_token']
+
+
+def _tweet(apikeys, status_id):
+    if bearer_token is None:
+        _refresh_token(apikeys)
+
+    resp = requests.get('{}/1.1/statuses/show.json?id={}&tweet_mode=extended'.format(
+        API,
+        status_id,
+    ), headers={
+        'Authorization': 'Bearer {}'.format(bearer_token),
+    })
+    resp.raise_for_status()
+
+    return resp.json()
+
+
+def _format_tweet(tweet):
+    contents = tweet['full_text']
+    media = tweet['extended_entities']['media']
+    if media:
+        contents = contents.replace(
+            media[0]['url'],
+            ' '.join([medium['media_url_https'] for medium in media]),
+        )
+    return '@{handle} ({realname}): {contents}'.format(
+        handle=tweet['user']['screen_name'],
+        realname=tweet['user']['name'],
+        contents=contents,
+    )
+
+
+def show_tweet(bot, msg):
+    """Show tweet content."""
+    tweet = _tweet(bot.twitter_apikeys, msg.match.group(2))
+    msg.respond(_format_tweet(tweet), ping=False)


### PR DESCRIPTION
Requires adding a new section to the config like so:

```
[twitter]
apikey=<"API key" from developer.twitter.com>
apisecret=<"API secret key" from developer.twitter.com>
```

I used a personal key to test but we should apply for an API key as an organization.

Closes #60.