### PR TITLE
Some small improvements to help text, message logging, and wide commands

### DIFF
--- a/ircbot/ircbot.py
+++ b/ircbot/ircbot.py
@@ -228,8 +228,9 @@ class CreateBot(irc.bot.SingleServerIRCBot):
                     )
                     listener.fn(self, msg)
 
-            # everything gets logged
-            self.recent_messages[event.target].appendleft((user, raw_text))
+            # everything gets logged except commands
+            if raw_text[0] != '!':
+                self.recent_messages[event.target].appendleft((user, raw_text))
 
     def on_currenttopic(self, connection, event):
         channel, topic = event.arguments

--- a/ircbot/ircbot.py
+++ b/ircbot/ircbot.py
@@ -53,14 +53,17 @@ MAX_CLIENT_MSG = 435
 
 class Listener(collections.namedtuple(
     'Listener',
-    ('pattern', 'fn', 'require_mention', 'require_oper', 'require_privileged_oper'),
+    ('pattern', 'fn', 'help_text', 'require_mention', 'require_oper', 'require_privileged_oper'),
 )):
 
     __slots__ = ()
 
     @property
     def help(self):
-        return self.fn.__doc__
+        if self.help_text:
+            return self.help_text
+        else:
+            return self.fn.__doc__
 
     @property
     def plugin_name(self):
@@ -146,6 +149,7 @@ class CreateBot(irc.bot.SingleServerIRCBot):
             pattern,
             fn,
             flags=0,
+            help_text=None,
             require_mention=False,
             require_oper=False,
             require_privileged_oper=False,
@@ -153,6 +157,7 @@ class CreateBot(irc.bot.SingleServerIRCBot):
         self.listeners.add(Listener(
             pattern=re.compile(pattern, flags),
             fn=fn,
+            help_text=help_text,
             require_mention=require_mention,
             require_oper=require_oper,
             require_privileged_oper=require_privileged_oper,

--- a/ircbot/plugin/templates/help.html
+++ b/ircbot/plugin/templates/help.html
@@ -18,7 +18,7 @@
             <ul>
                 {% for listener in listeners %}
                     <li>
-                        <code>{{listener.pattern.pattern}}</code>: {{listener.fn.__doc__.split('\n\n')[0]}}
+                        <code>{{listener.pattern.pattern}}</code>: {{listener.help.split('\n\n')[0]}}
                         {% if listener.require_mention %}
                             <strong>(requires mention)</strong>
                         {% endif %}

--- a/ircbot/plugin/wide.py
+++ b/ircbot/plugin/wide.py
@@ -4,9 +4,12 @@ from string import ascii_lowercase
 from string import ascii_uppercase
 
 WIDETEXT_MAP = {i: i + 0xFEE0 for i in range(0x21, 0x7F)}
+
 # the space character has unique mapping to become a unicode ideographic space
-WIDETEXT_MAP[ord(' ')] = 0x3000
-SPACE = chr(0x3000)
+WIDE_SPACE_VALUE = 0x3000
+WIDE_SPACE_CHAR = chr(WIDE_SPACE_VALUE)
+SPACE_VALUE = ord(' ')
+WIDETEXT_MAP[SPACE_VALUE] = WIDE_SPACE_VALUE
 
 # As seen in Samurai Jack
 THICC = '卂乃匚刀乇下厶卄工丁长乚从几口尸㔿尺丂丅凵リ山乂丫乙'
@@ -15,18 +18,34 @@ THICC = '卂乃匚刀乇下厶卄工丁长乚从几口尸㔿尺丂丅凵リ山�
 THICC_MAP = {
     **str.maketrans(ascii_lowercase, THICC),
     **str.maketrans(ascii_uppercase, THICC),
+    SPACE_VALUE: WIDE_SPACE_VALUE,
 }
 
 
 def register(bot):
-    bot.listen(r'^!w(.*)?', functools.partial(widetextify, width=0))  # wide text
-    bot.listen(r'^!2w(.*)?', functools.partial(widetextify, width=1))  # even wider text
-    bot.listen(r'^!3w(.*)?', functools.partial(widetextify, width=2))  # super wide text
+    bot.listen(
+        r'^!w(?:$| )(.*)?',
+        functools.partial(widetextify, width=0),
+        help_text='ｗｉｄｅｎ　ｔｅｘｔ',
+    )
+    bot.listen(
+        r'^!w2(?:$| )(.*)?',
+        functools.partial(widetextify, width=1),
+        help_text='ｗ　ｉ　ｄ　ｅ　ｎ　　　ｔ　ｅ　ｘ　ｔ　　　ｍ　ｏ　ｒ　ｅ',
+    )
+    bot.listen(
+        r'^!w3(?:$| )(.*)?',
+        functools.partial(widetextify, width=2),
+        help_text='ｓ　　ｕ　　ｐ　　ｅ　　ｒ　　　　　ｗ　　ｉ　　ｄ　　ｅ　　　　　ｔ　　ｅ　　ｘ　　ｔ',
+    )
+    bot.listen(
+        r'^!(?:thiccen|extrathicc)(?:$| )(.*)?',
+        functools.partial(widetextify, width=0, translation=THICC_MAP),
+        help_text='乇乂丅尺卂　丅卄工匚匚　丅乇乂丅',
+    )
 
-    bot.listen(r'^!thiccen(.*)?', thiccen)
 
-
-def get_text(bot, msg=None):
+def get_text(bot, msg):
     previous_message = bot.recent_messages[msg.channel]
 
     if msg.match.group(1).strip():
@@ -39,7 +58,7 @@ def get_text(bot, msg=None):
     return text.strip()
 
 
-def widetextify(bot, msg, width):
+def widetextify(bot, msg, width, translation=WIDETEXT_MAP):
     """ｗｅｌｃｏｍｅ　ｔｏ　ｔｈｅ　ｏｃｆ
 
     These activate either on text supplied after the trigger,
@@ -47,13 +66,7 @@ def widetextify(bot, msg, width):
     message in the channel.
     """
     text = get_text(bot, msg)
+
     if text:
-        response = (c.translate(WIDETEXT_MAP) + SPACE * width for c in text)
+        response = (c.translate(translation) + WIDE_SPACE_CHAR * width for c in text)
         msg.respond(''.join(response), ping=False)
-
-
-def thiccen(bot, msg):
-    """乇乂丅尺卂 丅卄工匚匚"""
-    text = get_text(bot, msg)
-    if text:
-        msg.respond(text.translate(THICC_MAP), ping=False)


### PR DESCRIPTION
This adds optional help text to listeners, removes message logging for commands, and adds help text for wide commands and does a bit more simplification to make thiccen a partial too.

This also makes thicc messages have more space between words, which makes the messages easier to actually read. (for example, `丅卄工丂 丅乇丂丅 从乇丂丂卂厶乇` becomes `丅卄工丂　丅乇丂丅　从乇丂丂卂厶乇`)