### PR TITLE
Add thread lock to IRC connection

### DIFF
--- a/ircbot/plugin/channels.py
+++ b/ircbot/plugin/channels.py
@@ -22,7 +22,8 @@ def join_channel(bot, channel):
                 'INSERT IGNORE INTO channels (channel) VALUES (%s)',
                 (channel,),
             )
-    bot.connection.join(channel)
+    with bot.sendmsg_lock:
+        bot.connection.join(channel)
 
 
 def on_invite(bot, conn, event):


### PR DESCRIPTION
The `irc` library uses Python sockets, which aren't thread-safe. This PR adds a lock and acquires the lock for any operation that sends to the IRC server.