### PR TITLE
Add a quotes page

### DIFF
--- a/ircbot/plugin/help.py
+++ b/ircbot/plugin/help.py
@@ -10,17 +10,23 @@ import jinja2
 def register(bot):
     threading.Thread(target=help_server, args=(bot,), daemon=True).start()
     bot.listen(r'^help$', help, require_mention=True)
-    bot.listen(r'^macros$', help_macro, require_mention=True)
+    bot.listen(r'^macros$', help_macros, require_mention=True)
+    bot.listen(r'^quotes$', help_quotes, require_mention=True)
 
 
 def help(bot, msg):
-    """Provide a link to this help page."""
+    """Provide a link to the help page."""
     msg.respond('https://ircbot.ocf.berkeley.edu/')
 
 
-def help_macro(bot, msg):
+def help_macros(bot, msg):
     """Provide a link to the list of macros."""
     msg.respond('https://ircbot.ocf.berkeley.edu/macros')
+
+
+def help_quotes(bot, msg):
+    """Provide a link to the list of quotes."""
+    msg.respond('https://ircbot.ocf.berkeley.edu/quotes')
 
 
 def build_request_handler(bot):
@@ -53,6 +59,11 @@ def build_request_handler(bot):
                 self.render_response(
                     'plugin/templates/macros.html',
                     macros=bot.plugins['macros'].list(bot),
+                )
+            elif self.path == '/quotes':
+                self.render_response(
+                    'plugin/templates/quotes.html',
+                    quotes=bot.plugins['quotes'].list(bot),
                 )
             else:
                 self.send_response(404, 'File not found')

--- a/ircbot/plugin/quotes.py
+++ b/ircbot/plugin/quotes.py
@@ -23,6 +23,7 @@ def rand(bot, msg):
         arg = msg.match.group(1).split()
     else:
         arg = []
+
     with db.cursor(password=bot.mysql_password) as c:
         c.execute(
             'SELECT * FROM quotes WHERE is_deleted = 0 ' +
@@ -94,3 +95,13 @@ def delete(bot, msg):
                 (quote_id,),
             )
         msg.respond('Quote #{} has been deleted.'.format(quote_id))
+
+
+def list(bot):
+    """List all quotes for the quotes list page."""
+
+    with db.cursor(password=bot.mysql_password) as c:
+        c.execute('SELECT * FROM quotes WHERE is_deleted = 0 ORDER BY id')
+
+    for quote in c.fetchall():
+        yield quote['id'], quote['quote']

--- a/ircbot/plugin/templates/quotes.html
+++ b/ircbot/plugin/templates/quotes.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <title>ocf ircbot quotes</title>
+        <style>
+          table {
+            border-collapse: collapse;
+          }
+          th, td {
+            border: 1px solid black;
+            padding: 4px;
+          }
+        </style>
+    </head>
+    <body>
+        <h1>ircbot quotes: <em>stupid stuff the OCF says</em></h1>
+        <hr />
+        <table>
+          <tbody>
+            <tr>
+              <th>ID</th>
+              <th>Quote</th>
+            </tr>
+            {% for id, quote in quotes %}
+              <tr>
+                <td>{{ id }}</td>
+                <td>{{ quote }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+    </body>
+</html>
+{# vim: ft=jinja
+#}


### PR DESCRIPTION
This is what the page looks like (well the top part anyway). I'd prefer to put a screenshot here than a live page link to my dev version when it might not be running and the link will very quickly get stale anyway:

![quotes-page](https://user-images.githubusercontent.com/1523594/51473416-269df580-1d31-11e9-8cdd-9c019dcf2e2d.png)

[rt#6832](https://rt.ocf.berkeley.edu/Ticket/Display.html?id=6832) is what inspired this, well that and me wanting a quotes page instead of trying to remember part of a quote and having to search for it...

I'd like to split out the web server from the help plugin and put it in its own plugin (and add hooks for other plugins to use it hopefully), but I think that can come in a future PR, it's not really related to this change at all.

Closes #147.