### PR TITLE
Corrected message splitting

### DIFF
--- a/ircbot/ircbot.py
+++ b/ircbot/ircbot.py
@@ -264,8 +264,20 @@ class CreateBot(irc.bot.SingleServerIRCBot):
         # The message must be split up if over the length limit
         if msg_len > MAX_CLIENT_MSG:
             # Split up the full message into chunks to send
-            msg_range = range(0, len(message), MAX_CLIENT_MSG)
-            messages = [message[i:i + MAX_CLIENT_MSG] for i in msg_range]
+            messages, msg = [], ''
+            count = 0
+
+            for char in message:
+                char_len = len(char.encode('utf-8'))
+                if count + char_len > MAX_CLIENT_MSG:
+                    messages.append(msg)
+                    count, msg = 0, ''
+
+                msg += char
+                count += char_len
+
+            if len(msg) != 0:
+                messages.append(msg)
 
             for msg in messages:
                 self.connection.privmsg(channel, msg)


### PR DESCRIPTION
Using the widetext command revealed a bug in the way ircbot splits messages longer than the max message length. Previously, messages were split based on the number of characters until reaching the max length. This fails when using unicode characters that are larger than one byte. Now ircbot counts the number of bytes of each character up until the max length and splits based on that. 