### PR TITLE
Adds ircbot command to ping staff in lab

### DIFF
--- a/ircbot/plugin/lab.py
+++ b/ircbot/plugin/lab.py
@@ -6,7 +6,7 @@ from ocflib.lab.stats import users_in_lab_count
 def register(bot):
     bot.listen(r'is ([a-z]+) in the lab', in_lab, require_mention=True)
     bot.listen(r"(who is|who's) in the lab", who_is_in_lab, require_mention=True)
-
+    bot.listen(r"@labstaff", ping_lab_staff, require_mention=False)
 
 def in_lab(bot, msg):
     """Check if a staffer is in the lab."""
@@ -44,3 +44,15 @@ def who_is_in_lab(bot, msg):
         len(staff),
         staff_list,
     ))
+
+def ping_lab_staff(bot, msg):
+    """Ping everyone who is currently in the lab."""
+    staff = {session.user for session in staff_in_lab()}
+    channel_users = bot.channels[msg.channel].users()
+    staff_nicks = set() 
+
+    for staff_username in staff:
+        staff_nicks = staff_nicks | {nick for nick in channel_users if nick.startswith(staff_username)}
+    nicks_string = ', '.join(sorted(staff_nicks))
+
+    msg.respond(msg.text.replace("@labstaff", nicks_string)) 


### PR DESCRIPTION
Adds a command to ping all staff in the lab. 

Currently bound to '@labstaff', which will trigger Create to repeat the message, with your name at the front, and a list of labstaff's nicks where you wrote '@labstaff'. An example can be seen below.
![screenshot_2019-02-01_17-39-43](https://user-images.githubusercontent.com/5742796/52157981-8b6a2180-2648-11e9-9cc9-4de5bbf4ae0c.png)

Suggest any formatting changes here.

Note that this does not currently do a proper slack ping. Normally when a user in irc types out a 'xxx-slack' username, its converted to a @xxx on Slack, but that doesn't seem to happen when a bot types it. That's something to change with the slackbridge though, not this.