### PR TITLE
display more info about Kanboard tasks (#106)

### DIFF
--- a/ircbot/ircbot.py
+++ b/ircbot/ircbot.py
@@ -109,6 +109,7 @@ class CreateBot(irc.bot.SingleServerIRCBot):
             googlesearch_key,
             googlesearch_cx,
             discourse_apikey,
+            kanboard_apikey,
             twitter_apikeys,
     ):
         self.recent_messages = collections.defaultdict(
@@ -124,6 +125,7 @@ class CreateBot(irc.bot.SingleServerIRCBot):
         self.googlesearch_key = googlesearch_key
         self.googlesearch_cx = googlesearch_cx
         self.discourse_apikey = discourse_apikey
+        self.kanboard_apikey = kanboard_apikey
         self.twitter_apikeys = twitter_apikeys
         self.listeners = set()
         self.plugins = {}
@@ -395,6 +397,7 @@ def main():
     googlesearch_key = conf.get('googlesearch', 'key')
     googlesearch_cx = conf.get('googlesearch', 'cx')
     discourse_apikey = conf.get('discourse', 'apikey')
+    kanboard_apikey = conf.get('kanboard', 'apikey')
     twitter_apikeys = (
         conf.get('twitter', 'apikey'),
         conf.get('twitter', 'apisecret'),
@@ -405,7 +408,7 @@ def main():
         tasks, nickserv_password, rt_password,
         weather_apikey, mysql_password, marathon_creds,
         googlesearch_key, googlesearch_cx, discourse_apikey,
-        twitter_apikeys,
+        kanboard_apikey, twitter_apikeys,
     )
     bot_thread = threading.Thread(target=bot.start, daemon=True)
     bot_thread.start()

--- a/ircbot/plugin/kanboard.py
+++ b/ircbot/plugin/kanboard.py
@@ -1,15 +1,21 @@
 """Kanboard is the hottest new thing"""
 import re
 
+from ocflib.infra.kanboard import KanboardError
+from ocflib.infra.kanboard import KanboardTask
+
 REGEX = re.compile(r'(?:k#)([0-9]+)')
 
 
 def register(bot):
-    bot.listen(REGEX.pattern, show_topic)
+    bot.listen(REGEX.pattern, show_task)
 
 
-def show_topic(bot, msg):
-    """Show the Kanboard topic and don't break the webserver ;)"""
-    for topic in REGEX.findall(msg.text):
-        id = int(topic)
-        msg.respond('https://ocf.io/k/' + str(id))
+def show_task(bot, msg):
+    """Show the Kanboard task and don't break the webserver ;)"""
+    for task in REGEX.findall(msg.text):
+        try:
+            k = KanboardTask.from_number('jsonrpc', bot.kanboard_apikey, int(task))
+            msg.respond(str(k))
+        except KanboardError:
+            pass


### PR DESCRIPTION
This should work. The only problem is that querying the KanboardTask is 401'ing. My suspicion is that the apikey in /etc/ocf-ircbot/ocf-ircbot.conf isn't right but I can't really check that since I'm not an admin on Kanboard.