### PR TITLE
Use new semantic analyzer with mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 # TODO: enable more flags like in https://github.com/ocf/slackbridge/blob/master/mypy.ini
+new_semantic_analyzer = True
 show_traceback = True
 ignore_missing_imports = True
 check_untyped_defs = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ aspy.yaml==1.2.0
 atomicwrites==1.3.0
 cfgv==1.6.0
 identify==1.4.3
-mypy==0.701
+mypy==0.711
 mypy-extensions==0.4.1
 nodeenv==1.3.3
 pluggy==0.11.0
@@ -12,6 +12,5 @@ pytest==4.5.0
 requirements-tools==1.2.1
 setuptools==41.0.1
 toml==0.10.0
-typed-ast==1.3.5
 virtualenv==16.6.0
 wcwidth==0.1.7


### PR DESCRIPTION
This will soon become the default.

Also I deleted `typed_ast` from the requirements-dev.txt, I'm not sure why it was there in the first place (its a dependency of mypy).