### PR TITLE
don't cast F2C conversion to int

### DIFF
--- a/ircbot/plugin/weather.py
+++ b/ircbot/plugin/weather.py
@@ -21,7 +21,7 @@ def weather(bot, msg):
 
 
 def f2c(temp):
-    return int((temp - 32) * 5 / 9)
+    return (temp - 32) * 5 / 9
 
 
 def deg_to_compass(deg):


### PR DESCRIPTION
prevents rounding errors that show the wrong emoji when displaying temp as Celsius