### PR TITLE
Handle invalid characters in shorturls/add

### DIFF
--- a/ircbot/plugin/shorturls.py
+++ b/ircbot/plugin/shorturls.py
@@ -47,6 +47,8 @@ def add(bot, msg):
             msg.respond(
                 'shorturl already exists, did you mean `!shorturl replace`?',
             )
+        except ValueError as e:
+            msg.respond(e)
         else:
             msg.respond(f'shorturl added as `{slug}`')
 


### PR DESCRIPTION
To address: #151

When a `ValueError` is raised, send the error message back to the user.

Test usage:
```
<zachary> !shorturl add ^badurl ~zachary
<create-zachary> zachary: shorturl '^badurl' contains illegal characters
```