### PR TITLE
webserver: add webhook for prometheus alerts

### DIFF
--- a/ircbot/plugin/webserver.py
+++ b/ircbot/plugin/webserver.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from flask import Flask
 from flask import render_template
+from flask import request
 
 if TYPE_CHECKING:
     from ircbot.ircbot import Listener
@@ -50,6 +51,25 @@ def route_macros():
         'macros.html',
         macros=app.bot.plugins['macros'].list(app.bot),
     )
+
+
+@app.route('/hook/prometheus', methods=['POST'])
+def route_prometheus():
+    body_json = request.get_json()
+    for alert in body_json['alerts']:
+        if alert['status'] == 'resolved':
+            status = '\x02\x0303OK\x0F'
+        else:
+            status = '\x02\x0304FIRING\x0F'
+
+        alert = '{status} \x02{alertname}\x0F: {summary}'.format(
+            status=status,
+            alertname=alert['labels']['alertname'],
+            summary=alert['annotations']['summary'],
+        )
+        app.bot.say('#rebuild-spam', alert)
+
+    return ('', 204)
 
 
 def start_server(bot):


### PR DESCRIPTION
This is pretty much a copy of the code from #76.

We'll start off with the #rebuild-spam channel for now, but if this works out well we can extend this to use custom channels (configured by Prometheus) and then utilize the #opstaff-alerts channel.

It looks like this:

```
<create> OK TestAlert: This is what a Prometheus alert looks like
```

In IRC, `OK` or `FIRING` show up as green and red respectively, and the part before the colon is bold.