### PR TITLE
Add `update` keyword as alias for `replace`

### DIFF
--- a/ircbot/plugin/macros.py
+++ b/ircbot/plugin/macros.py
@@ -1,7 +1,7 @@
 """Provide OCF image macros, inspired by Phabricator Macros"""
 from ircbot import db
 
-KEYWORDS = {'add', 'delete', 'rename', 'replace'}
+KEYWORDS = {'add', 'delete', 'rename', 'replace', 'update'}
 
 
 def register(bot):
@@ -10,6 +10,7 @@ def register(bot):
     bot.listen(r'^#m delete (\w+)$', delete)
     bot.listen(r'^#m rename (\w+) (\w+)$', rename)
     bot.listen(r'^#m replace (\w+) (.+)$', replace)
+    bot.listen(r'^#m update (\w+) (.+)$', replace)
 
 
 def show(bot, msg):

--- a/ircbot/plugin/macros.py
+++ b/ircbot/plugin/macros.py
@@ -9,8 +9,7 @@ def register(bot):
     bot.listen(r'^#m add (\w+) (.+)$', add)
     bot.listen(r'^#m delete (\w+)$', delete)
     bot.listen(r'^#m rename (\w+) (\w+)$', rename)
-    bot.listen(r'^#m replace (\w+) (.+)$', replace)
-    bot.listen(r'^#m update (\w+) (.+)$', replace)
+    bot.listen(r'^#m (?:replace|update) (\w+) (.+)$', replace)
 
 
 def show(bot, msg):

--- a/ircbot/plugin/shorturls.py
+++ b/ircbot/plugin/shorturls.py
@@ -14,6 +14,7 @@ def register(bot):
     bot.listen(r'^!shorturl delete ([^ ]+)$', delete, require_oper=True)
     bot.listen(r'^!shorturl rename ([^ ]+) ([^ ]+)$', rename, require_oper=True)
     bot.listen(r'^!shorturl replace ([^ ]+) (.+)$', replace, require_oper=True)
+    bot.listen(r'^!shorturl update ([^ ]+) (.+)$', replace, require_oper=True)
 
 
 def show(bot, msg):

--- a/ircbot/plugin/shorturls.py
+++ b/ircbot/plugin/shorturls.py
@@ -13,8 +13,7 @@ def register(bot):
     bot.listen(r'^!shorturl add ([^ ]+) (.+)$', add, require_oper=True)
     bot.listen(r'^!shorturl delete ([^ ]+)$', delete, require_oper=True)
     bot.listen(r'^!shorturl rename ([^ ]+) ([^ ]+)$', rename, require_oper=True)
-    bot.listen(r'^!shorturl replace ([^ ]+) (.+)$', replace, require_oper=True)
-    bot.listen(r'^!shorturl update ([^ ]+) (.+)$', replace, require_oper=True)
+    bot.listen(r'^!shorturl (?:replace|update) ([^ ]+) (.+)$', replace, require_oper=True)
 
 
 def show(bot, msg):


### PR DESCRIPTION
* Updated shorturls and macros to use alias
* Alias could be edited to use a proxy function that can appear differently on ircbot.ocf.berkeley.edu