### PR TITLE
Fix Emoji handling for wide.py

### DIFF
--- a/ircbot/plugin/wide.py
+++ b/ircbot/plugin/wide.py
@@ -86,7 +86,7 @@ def widetextify(bot, msg, width, translation=WIDETEXT_MAP):
                     response += text[i]
                 else:
                     response += text[i] + WIDE_SPACE_CHAR * width
-            elif text[i] == 0x200d:
+            elif ord(text[i]) == 0x200d:
                     response += text[i]
             else:
                     response += text[i] + WIDE_SPACE_CHAR * width

--- a/ircbot/plugin/wide.py
+++ b/ircbot/plugin/wide.py
@@ -60,6 +60,13 @@ def get_text(bot, msg):
 
     return text.strip()
 
+def is_emoji(c):
+    if ord(c) in range(0x1f300, 0x1fadf):
+        return True
+    else:
+        return False
+
+
 
 def widetextify(bot, msg, width, translation=WIDETEXT_MAP):
     """ｗｅｌｃｏｍｅ　ｔｏ　ｔｈｅ　ｏｃｆ
@@ -71,5 +78,5 @@ def widetextify(bot, msg, width, translation=WIDETEXT_MAP):
     text = get_text(bot, msg)
 
     if text:
-        response = (c.translate(translation) + WIDE_SPACE_CHAR * width for c in text)
+        response = (c.translate(translation) + WIDE_SPACE_CHAR * width if ord(c) is not 0x200d and not is_emoji(c) else c for c in text)
         msg.respond(''.join(response), ping=False)

--- a/ircbot/plugin/wide.py
+++ b/ircbot/plugin/wide.py
@@ -61,7 +61,7 @@ def get_text(bot, msg):
     return text.strip()
 
 def is_emoji(c):
-    if ord(c) in range(0x1f300, 0x1fadf):
+    if ord(c) in range(0x1f300, 0x1fadf) or ord(c) in range(0x2700, 0x27bf):
         return True
     else:
         return False
@@ -76,7 +76,19 @@ def widetextify(bot, msg, width, translation=WIDETEXT_MAP):
     message in the channel.
     """
     text = get_text(bot, msg)
-
+    response = ''
+    char_is_emoji = False
     if text:
-        response = (c.translate(translation) + WIDE_SPACE_CHAR * width if ord(c) is not 0x200d and not is_emoji(c) else c for c in text)
+
+        for i in range(len(text)):
+            if is_emoji(text[i]) and i < len(text):
+                if ord(text[i + 1]) == 0x200d or ord(text[i + 1]) == 0xfe0f:
+                    response += text[i]
+                else:
+                    response += text[i] + WIDE_SPACE_CHAR * width
+            elif text[i] == 0x200d:
+                    response += text[i]
+            else:
+                    response += text[i] + WIDE_SPACE_CHAR * width
+
         msg.respond(''.join(response), ping=False)

--- a/ircbot/plugin/wide.py
+++ b/ircbot/plugin/wide.py
@@ -84,7 +84,7 @@ def widetextify(bot, msg, width, translation=WIDETEXT_MAP):
                     response += text[i]
                 else:
                     response += text[i] + WIDE_SPACE_CHAR * width
-            elif ord(text[i]) == 0x200d:
+            elif ord(text[i]) == 0x200d and i < len(text) - 1:
                     response += text[i]
             else:
                     response += text[i].translate(translation) + WIDE_SPACE_CHAR * width

--- a/ircbot/plugin/wide.py
+++ b/ircbot/plugin/wide.py
@@ -77,9 +77,7 @@ def widetextify(bot, msg, width, translation=WIDETEXT_MAP):
     """
     text = get_text(bot, msg)
     response = ''
-    char_is_emoji = False
     if text:
-
         for i in range(len(text)):
             if is_emoji(text[i]) and i < len(text) - 1:
                 if ord(text[i + 1]) == 0x200d or ord(text[i + 1]) == 0xfe0f:

--- a/ircbot/plugin/wide.py
+++ b/ircbot/plugin/wide.py
@@ -81,7 +81,7 @@ def widetextify(bot, msg, width, translation=WIDETEXT_MAP):
     if text:
 
         for i in range(len(text)):
-            if is_emoji(text[i]) and i < len(text):
+            if is_emoji(text[i]) and i < len(text) - 1:
                 if ord(text[i + 1]) == 0x200d or ord(text[i + 1]) == 0xfe0f:
                     response += text[i]
                 else:

--- a/ircbot/plugin/wide.py
+++ b/ircbot/plugin/wide.py
@@ -89,6 +89,6 @@ def widetextify(bot, msg, width, translation=WIDETEXT_MAP):
             elif ord(text[i]) == 0x200d:
                     response += text[i]
             else:
-                    response += c.translate(translation) + WIDE_SPACE_CHAR * width
+                    response += text[i].translate(translation) + WIDE_SPACE_CHAR * width
 
         msg.respond(''.join(response), ping=False)

--- a/ircbot/plugin/wide.py
+++ b/ircbot/plugin/wide.py
@@ -89,6 +89,6 @@ def widetextify(bot, msg, width, translation=WIDETEXT_MAP):
             elif ord(text[i]) == 0x200d:
                     response += text[i]
             else:
-                    response += text[i] + WIDE_SPACE_CHAR * width
+                    response += c.translate(translation) + WIDE_SPACE_CHAR * width
 
         msg.respond(''.join(response), ping=False)


### PR DESCRIPTION
Some emojis are comprised of more than one Unicode characters, joined by the Zero Width Joiner (U+200D). In its current form, create breaks those emojis apart (for example, `!w2 👨‍✈️` returns `👨　‍　✈　️　`.

My pull request aims to fix this behavior. Everything seems to work as intended during my limited testing.